### PR TITLE
Set correct call to innobackupex binary

### DIFF
--- a/templates/xtrabackup.sh.erb
+++ b/templates/xtrabackup.sh.erb
@@ -60,7 +60,8 @@ run_innobackupx() {
   time innobackupex ${INNOBACKUPX_OPTIONS} ${BACKUP_LOCATION} >> $LOGFILE 2>&1
   check_status
   log "INFO: Preparing backup files"
-  time innobackupx --apply-log $BACKUP_LOCATION >> $LOGFILE 2>&1
+  INNOBACKUP_LOCATION=$(find ${BACKUP_LOCATION}/* -type d -print -quit)
+  time innobackupex --apply-log $INNOBACKUP_LOCATION >> $LOGFILE 2>&1
   check_status
   log "INFO: Backup Process Complete"
 }


### PR DESCRIPTION
Small fix for a typo in innobackupex binary name call. There is a mismatch to that and the function names, but I've left those as is due to ensuring compatibility with existing puppet code. Also sets the correct path for innobackupex so it can apply the log